### PR TITLE
Fix incorrect fossil node area specification.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -583,18 +583,33 @@ int main(int argc, char* argv[]){
 			/*
 			 * setting up fossils
 			 */
-			for(unsigned int k=0;k<fossiltype.size();k++){
-				if(fossiltype[k] == "n" || fossiltype[k] == "N"){
-					bgt.setFossilatNodeByMRCA_id(mrcanodeint[fossilmrca[k]],areanamemap[fossilarea[k]]);
-					cout << "Setting node fossil at mrca: " << fossilmrca[k] << " at area: " << fossilarea[k] << endl;
-				}else if(fossiltype[k] == "b" || fossiltype[k] == "B"){
-					if (mrcanodeint[fossilmrca[k]]->isInternal()) {
-						bgt.setFossilatInternalBranchByMRCA_id(mrcanodeint[fossilmrca[k]],areanamemap[fossilarea[k]],fossilage[k]);
-						cout << "Setting INTERNAL branch fossil at mrca: " << fossilmrca[k] << " at area: " << fossilarea[k] << " at age: " << fossilage[k] << endl;
+			for (std::size_t k{0}; k < fossiltype.size(); ++k) {
+        const auto& type{fossiltype.at(k)};
+        const auto& mrca{fossilmrca.at(k)};
+        if (!mrcanodeint.count(mrca)) {
+          std::cerr << "ERROR: undefined MRCA: " << mrca << std::endl;
+          exit(1);
+        }
+        const auto& node_id{mrcanodeint.at(mrca)};
+        const auto& area_name{fossilarea.at(k)};
+        if (!areanamemap.count(area_name)) {
+          std::cerr << "ERROR: undefined area name for " << mrca
+                    << ": " << area_name << std::endl;
+          exit(1);
+        }
+        const auto& area_id{areanamemap.at(area_name)};
+        const auto& age{fossilage.at(k)};
+				if(type == "n" || type == "N"){
+					bgt.setFossilatNodeByMRCA_id(node_id, area_id);
+					cout << "Setting node fossil at mrca: " << mrca << " at area: " << area_name << endl;
+				}else if(type == "b" || type == "B"){
+					if (node_id->isInternal()) {
+						bgt.setFossilatInternalBranchByMRCA_id(node_id, area_id, age);
+						cout << "Setting INTERNAL branch fossil at mrca: " << mrca << " at area: " << area_name << " at age: " << age << endl;
 					}
 					else {
-						bgt.setFossilatExternalBranchByMRCA_id(mrcanodeint[fossilmrca[k]],areanamemap[fossilarea[k]],fossilage[k]);
-						cout << "Setting EXTERNAL branch fossil at mrca: " << fossilmrca[k] << " at area: " << fossilarea[k] << " at age: " << fossilage[k] << endl;
+						bgt.setFossilatExternalBranchByMRCA_id(node_id, area_id, age);
+						cout << "Setting EXTERNAL branch fossil at mrca: " << mrca << " at area: " << area_name << " at age: " << age << endl;
 					}
 				}
 			}


### PR DESCRIPTION
Hello, I'm working with Fabien Condamine to refresh DECX's interface a little bit, and I came accross a bug with the `fossil` option, which I offer to fix here.

Users are incorrectly providing distributions instead of single area names. For example, fossil lines should look like:
```
fossil= n Caiman a
```
But they instead write things like:
```
fossil= n Caiman 010
```
However, instead of crashing in this case where the area name is incorrect, DECX falls back on the first area defined in the `areanames` list. (this is (very) unfortunately how C++ handles [unexistent keys in maps](https://stackoverflow.com/q/10124679/3719101) with the common syntax `map[key]` )

As a consequence, the two above lines provide the same result, which is not at all expected by user.

The PR is a just quickfix to make DECX crash with an error instead when it encounters the second line.

Also, it is a friendly ping @champost because I hear you've gone AWOL. Are you okay? :) Are you still active on github? Are willing to keep accepting PRs on this project? If not, would you agree that I become co-maintainer of DECX?

Sincerely,